### PR TITLE
fix stray stream issue

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -22,12 +22,9 @@ impl Client {
         let (ret, recv) = oneshot::channel();
         let op = Op::OpenStream { ret };
         self.conn_sender.send(op).map_err(|_| Error::Shutdown)?;
-        let stream_id = recv.await.map_err(|_| Error::Shutdown)?;
+        let stream = recv.await.map_err(|_| Error::Shutdown)?;
 
-        Ok(Stream {
-            stream_id,
-            conn_sender: self.conn_sender.clone(),
-        })
+        Ok(stream)
     }
 
     /// Client shutdown.

--- a/src/op.rs
+++ b/src/op.rs
@@ -2,10 +2,11 @@ use tokio::sync::oneshot;
 
 use crate::error::Result;
 use crate::proto::{Batch, BatchResult, Stmt, StmtResult};
+use crate::Stream;
 
 pub(crate) enum Op {
     OpenStream {
-        ret: oneshot::Sender<i32>,
+        ret: oneshot::Sender<Stream>,
     },
     Execute {
         stmt: Stmt,


### PR DESCRIPTION
Fixes a bug where a stream could never be closed, while its id was recollected if the receiver of `open_stream` never constructed the stream (like by not awaiting the future).
