### PR TITLE
add with_connector method to client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ thiserror = "1.0.40"
 tokio = { version = "1.22.2", features = ["net", "sync", "rt", "macros"] }
 tokio-tungstenite = { version = "0.18", features = ["rustls-tls-webpki-roots"] }
 hrana-client-proto = { version = "0", path = "./hrana-client-proto" }
+tower = { version = "0.4.13", features = ["make"] }
+hyper = { version = "0.14.27", features = ["tcp", "client"] }
 
 [dev-dependencies]
 tokio = { version = "1.22.2", features = ["rt-multi-thread"] }

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -1,7 +1,4 @@
-use hrana_client::{
-    proto::Stmt,
-    Client,
-};
+use hrana_client::{proto::Stmt, Client};
 
 #[tokio::main]
 async fn main() {
@@ -22,8 +19,14 @@ async fn main() {
         None,
         Stmt::new("CREATE TABLE IF NOT EXISTS test (id INT, name TEXT)", true),
     );
-    batch.step(None, Stmt::new("INSERT INTO test (id, name) VALUES (1, 2)", true));
-    batch.step(None, Stmt::new("INSERT INTO test (id, name) VALUES (2, 3)", true));
+    batch.step(
+        None,
+        Stmt::new("INSERT INTO test (id, name) VALUES (1, 2)", true),
+    );
+    batch.step(
+        None,
+        Stmt::new("INSERT INTO test (id, name) VALUES (2, 3)", true),
+    );
     batch.step(None, Stmt::new("SELECT * FROM test", true));
 
     let resp = stream.execute_batch(batch).await.unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,10 @@ pub enum Error {
     RequestDoesNotExist,
     #[error("connection state is invalid")]
     InvalidState,
+    #[error("invalid URI: {0}")]
+    InvalidUri(#[from] Arc<hyper::http::uri::InvalidUri>),
+    #[error("connect error: {0}")]
+    Connect(Arc<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 impl From<tungstenite::Error> for Error {


### PR DESCRIPTION
The PR adds the ability to provide a custom connector to perform io instead of only plain `tokio::net::TcpStream`.
